### PR TITLE
Change CLI Argument Parser to catch 'help'.

### DIFF
--- a/clldutils/clilib.py
+++ b/clldutils/clilib.py
@@ -28,7 +28,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
     def main(self, args=None, catch_all=False):
         args = self.parse_args(args=args)
-        if args.command == 'help':
+        if args.command == 'help' and len(args.args):
             # As help text for individual commands we simply re-use the docstrings of the
             # callables registered for the command:
             print(self.commands[args.args[0]].__doc__)


### PR DESCRIPTION
Currently the ArgumentParser treats 'help' as a special keyword and when invoked it looks for the docstring on arg2 (e.g. "util.py help foo" prints foo.__doc__). However, I keep typing 'util.py help' with no second argument. This generates a traceback:

```
Traceback (most recent call last):
  File "/Users/simon/files/Projects/lexibank_project/env/bin/lexibank", line 11, in <module>
    load_entry_point('pylexibank', 'console_scripts', 'lexibank')()
  File "/Users/simon/files/Projects/lexibank_project/lexibank-data/pylexibank/cli.py", line 454, in main
    sys.exit(parser.main())
  File "/Users/simon/files/Projects/lexibank_project/env/lib/python3.5/site-packages/clldutils-1.5.4-py3.5.egg/clldutils/clilib.py", line 34, in main
    print(self.commands[args.args[0]].__doc__)
IndexError: list index out of range
```

...because args.args is empty. This patch alters the behavior to check for `help` with 1 or more arguments. With one argument, the correct help is called, with no arguments, we fall through to print `parser. print_help()` as 'help' is unlikely to be a defined function in child packages. 

Could make this more explicit by catching 'help' with 0 args vs > 0 args, but this is the simplest solution.
