### PR TITLE
adding simple text manipulation options

### DIFF
--- a/clldutils/tests/test_text.py
+++ b/clldutils/tests/test_text.py
@@ -1,0 +1,17 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division
+from clldutils.text import *
+
+def test_strip_brackets():
+    strings = ['arm(hand)', '(hand)arm', 'a(hand)r(hand)m(hand)', 'arm⁽hand⁾']
+    for string in strings:
+        assert strip_brackets(string) == 'arm'
+    assert strip_brackets('arm<hand>', brackets={"<": ">"}) == 'arm'
+
+def test_split_text():
+    assert split_text('arm/hand')[1] == 'hand'
+    assert split_text('arm,hand;foot')[2] == 'foot'
+    assert split_text('arm/,;hand')[0] == 'arm'
+
+def test_strip_chars():
+    assert strip_chars('b', 'abcabc') == 'acac'

--- a/clldutils/tests/test_text.py
+++ b/clldutils/tests/test_text.py
@@ -12,6 +12,8 @@ def test_split_text():
     assert split_text('arm/hand')[1] == 'hand'
     assert split_text('arm,hand;foot')[2] == 'foot'
     assert split_text('arm/,;hand')[0] == 'arm'
+    assert split_text('arm/,;hand')[1] == 'hand'
+    assert split_text('arm/')[0] == 'arm'
 
 def test_strip_chars():
     assert strip_chars('b', 'abcabc') == 'acac'

--- a/clldutils/text.py
+++ b/clldutils/text.py
@@ -1,0 +1,34 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division
+import re
+
+def strip_brackets(text, brackets=None):
+    """Strip brackets and what is inside brackets from text.
+    
+    .. bite:: If the text contains only one opening bracket, the rest of the text
+      will be ignored. This is a feature, not a bug, as we want to avoid that
+      this function raises errors too easily.
+    """
+    brackets = brackets or {
+            "(": ")", "{": "}", "[": "]", "（": "）", "【": "】", "『": "』",
+            "«": "»", "⁽": "⁾", "₍": "₎"}
+    stack = []
+    tmp_sequence = list(text)
+    new_sequence = ''
+    while tmp_sequence:
+        itm = tmp_sequence.pop(0)
+        if itm in brackets:
+            stack += [brackets[itm]]
+        if not stack:
+            new_sequence += itm
+        if itm in stack:
+            stack.pop(stack.index(itm))
+    return new_sequence
+
+def split_text(text, separators="/,;~"):
+    """Split text along the separators."""
+    return re.split(r'\s*['+separators+']+\s*', text)
+
+def strip_chars(chars, sequence):
+    """Strip the specified chars from anywhere in the text."""
+    return ''.join([s for s in sequence if s not in chars])

--- a/clldutils/text.py
+++ b/clldutils/text.py
@@ -13,9 +13,8 @@ def strip_brackets(text, brackets=None):
             "(": ")", "{": "}", "[": "]", "（": "）", "【": "】", "『": "』",
             "«": "»", "⁽": "⁾", "₍": "₎"}
     stack = []
-    tmp_sequence = list(text)
     new_sequence = ''
-    for itm in tmp_sequence:
+    for itm in text:
         if itm in brackets:
             stack += [brackets[itm]]
         if not stack:

--- a/clldutils/text.py
+++ b/clldutils/text.py
@@ -15,8 +15,7 @@ def strip_brackets(text, brackets=None):
     stack = []
     tmp_sequence = list(text)
     new_sequence = ''
-    while tmp_sequence:
-        itm = tmp_sequence.pop(0)
+    for itm in tmp_sequence:
         if itm in brackets:
             stack += [brackets[itm]]
         if not stack:

--- a/clldutils/text.py
+++ b/clldutils/text.py
@@ -27,7 +27,7 @@ def strip_brackets(text, brackets=None):
 
 def split_text(text, separators="/,;~"):
     """Split text along the separators."""
-    return re.split(r'\s*['+separators+']+\s*', text)
+    return [x for x in re.split(r'\s*['+separators+']+\s*', text) if x.strip()]
 
 def strip_chars(chars, sequence):
     """Strip the specified chars from anywhere in the text."""


### PR DESCRIPTION
Important aspects:

* if a bracket is not closed, the whole rest of the string is ignored, thus ```strip_brackets("arm(hand")``` yields ```"arm"```, which is important as many linguistic dataset contain these kind of errors
* if a text piece ends on a separator, this is ignored, thus only "full" forms are retained, and ```split_text('foot/')``` just yields ```foot``` 