### PR TITLE
Add warning for subcommands that are missing docstrings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'dev': ['flake8', 'wheel', 'twine'],
         'test': [
             'mock',
-            'pytest>=3.6',
+            'pytest>=5.4',
             'pytest-mock',
             'pytest-cov',
             'coverage>=4.2',

--- a/src/clldutils/clilib.py
+++ b/src/clldutils/clilib.py
@@ -191,8 +191,7 @@ def register_subcommands(subparsers, pkg, entry_point=None, formatter_class=Form
 
     for name, mod in _cmds.items():
         if not mod.__doc__:
-            warnings.warn('Command \"{0}\" is missing a docstring.'.format(name))
-            raise ValueError
+            raise ValueError('Command \"{0}\" is missing a docstring.'.format(name))
 
         subparser = subparsers.add_parser(
             name,

--- a/src/clldutils/clilib.py
+++ b/src/clldutils/clilib.py
@@ -190,6 +190,10 @@ def register_subcommands(subparsers, pkg, entry_point=None, formatter_class=Form
                 [('.'.join([ep.name, name]), mod) for name, mod in iter_modules(pkg)])
 
     for name, mod in _cmds.items():
+        if not mod.__doc__:
+            warnings.warn('Command \"{0}\" is missing a docstring.'.format(name))
+            raise ValueError
+
         subparser = subparsers.add_parser(
             name,
             help=mod.__doc__.strip().splitlines()[0] if mod.__doc__.strip() else '',

--- a/tests/fixtures/problematic_commands/cmd.py
+++ b/tests/fixtures/problematic_commands/cmd.py
@@ -1,0 +1,6 @@
+def register(z):  # pragma: no cover
+    z.add_argument('-f', help='f', default='z')
+
+
+def run(args):
+    pass  # pragma: no cover

--- a/tests/test_clilib.py
+++ b/tests/test_clilib.py
@@ -57,6 +57,7 @@ def test_register_subcommands(fixtures_dir, mocker):
 def test_register_subcommands_error(fixtures_dir, mocker, recwarn):
     with sys_path(fixtures_dir):
         pkg = importlib.import_module('commands')
+        pkg_problematic = importlib.import_module('problematic_commands')
         class EP:
             name = 'abc'
             def load(self):
@@ -65,6 +66,8 @@ def test_register_subcommands_error(fixtures_dir, mocker, recwarn):
             'clldutils.clilib.pkg_resources',
             mocker.Mock(iter_entry_points=mocker.Mock(return_value=[EP()])))
         _, sp = get_parser_and_subparsers('a')
+        with pytest.raises(ValueError):
+            _ = register_subcommands(sp, pkg_problematic, entry_point='x')
         res = register_subcommands(sp, pkg, entry_point='x')
         assert 'abc.cmd' not in res
         assert recwarn.pop(UserWarning)


### PR DESCRIPTION
Closes #92.